### PR TITLE
IDEMPIERE-4618 add org.eclipse.jetty.util to swingclient.product.launch

### DIFF
--- a/org.adempiere.report.jasper.swing/META-INF/MANIFEST.MF
+++ b/org.adempiere.report.jasper.swing/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: JasperReports Swing Client
 Bundle-SymbolicName: org.adempiere.report.jasper.swing;singleton:=true
-Bundle-Version: 8.1.0.qualifier
+Bundle-Version: 8.2.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version>=11))"
 Require-Bundle: org.adempiere.base;bundle-version="0.0.0",

--- a/org.adempiere.report.jasper.swing/pom.xml
+++ b/org.adempiere.report.jasper.swing/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.idempiere.swing.client</groupId>
 		<artifactId>org.idempiere.swing.client.parent</artifactId>
-		<version>8.1.0-SNAPSHOT</version>
+		<version>8.2.0-SNAPSHOT</version>
 		<relativePath>../org.idempiere.swing.client.parent/pom.xml</relativePath>
 	</parent>
 	<artifactId>org.adempiere.report.jasper.swing</artifactId>

--- a/org.adempiere.ui.swing-feature/feature.xml
+++ b/org.adempiere.ui.swing-feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.adempiere.ui.swing.feature"
       label="Swing Client-feature"
-      version="8.1.0.qualifier"
+      version="8.2.0.qualifier"
       provider-name="iDempiere Community">
 
    <description url="http://www.example.com/description">

--- a/org.adempiere.ui.swing-feature/pom.xml
+++ b/org.adempiere.ui.swing-feature/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.idempiere.swing.client</groupId>
 		<artifactId>org.idempiere.swing.client.parent</artifactId>
-		<version>8.1.0-SNAPSHOT</version>
+		<version>8.2.0-SNAPSHOT</version>
 		<relativePath>../org.idempiere.swing.client.parent/pom.xml</relativePath>
 	</parent>
 	<artifactId>org.adempiere.ui.swing.feature</artifactId>

--- a/org.adempiere.ui.swing-feature/swingclient.product.launch
+++ b/org.adempiere.ui.swing-feature/swingclient.product.launch
@@ -284,6 +284,7 @@
         <setEntry value="org.eclipse.equinox.simpleconfigurator@1:true"/>
         <setEntry value="org.eclipse.jdt.core@default:default"/>
         <setEntry value="org.eclipse.jetty.osgi-servlet-api@default:default"/>
+        <setEntry value="org.eclipse.jetty.util@default:default"/>
         <setEntry value="org.eclipse.osgi.compatibility.state@default:false"/>
         <setEntry value="org.eclipse.osgi.services@default:default"/>
         <setEntry value="org.eclipse.osgi.util@default:default"/>

--- a/org.adempiere.ui.swing/META-INF/MANIFEST.MF
+++ b/org.adempiere.ui.swing/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: iDempiere Swing Client
 Bundle-SymbolicName: org.adempiere.ui.swing;singleton:=true
-Bundle-Version: 8.1.0.qualifier
+Bundle-Version: 8.2.0.qualifier
 Bundle-ClassPath: .,
  lib/jpedal.jar,
  lib/looks.jar,
@@ -72,7 +72,7 @@ Require-Bundle: org.adempiere.base;bundle-version="0.0.0",
  org.adempiere.ui;bundle-version="0.0.0",
  org.jfree.chart;bundle-version="1.0.19",
  org.jfree.jcommon;bundle-version="1.0.23",
- org.adempiere.plugin.utils;bundle-version="8.1.0"
+ org.adempiere.plugin.utils;bundle-version="8.2.0"
 Eclipse-ExtensibleAPI: true
 Eclipse-RegisterBuddy: org.adempiere.base
 Bundle-RequiredExecutionEnvironment: JavaSE-11

--- a/org.adempiere.ui.swing/pom.xml
+++ b/org.adempiere.ui.swing/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.idempiere.swing.client</groupId>
 		<artifactId>org.idempiere.swing.client.parent</artifactId>
-		<version>8.1.0-SNAPSHOT</version>
+		<version>8.2.0-SNAPSHOT</version>
 		<relativePath>../org.idempiere.swing.client.parent/pom.xml</relativePath>
 	</parent>
 	<artifactId>org.adempiere.ui.swing</artifactId>

--- a/org.idempiere.swing.client.p2/category.xml
+++ b/org.idempiere.swing.client.p2/category.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
-   <feature url="features/org.adempiere.ui.swing.feature_8.1.0.qualifier.jar" id="org.adempiere.ui.swing.feature" version="8.1.0.qualifier">
+   <feature url="features/org.adempiere.ui.swing.feature_8.2.0.qualifier.jar" id="org.adempiere.ui.swing.feature" version="8.2.0.qualifier">
       <category name="idempiere.swing.client"/>
    </feature>
    <category-def name="idempiere.swing.client" label="idempiere swing client"/>

--- a/org.idempiere.swing.client.p2/pom.xml
+++ b/org.idempiere.swing.client.p2/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.idempiere.swing.client</groupId>
 		<artifactId>org.idempiere.swing.client.parent</artifactId>
-		<version>8.1.0-SNAPSHOT</version>
+		<version>8.2.0-SNAPSHOT</version>
 		<relativePath>../org.idempiere.swing.client.parent/pom.xml</relativePath>
 	</parent>
 	<artifactId>org.idempiere.swing.client.p2</artifactId>

--- a/org.idempiere.swing.client.p2/swingclient.product
+++ b/org.idempiere.swing.client.p2/swingclient.product
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?pde version="3.5"?>
 
-<product name="idempiere Swing Client" uid="org.adempiere.ui.swing.product" id="org.adempiere.ui.swing.client_product" application="org.adempiere.ui.swing.client" version="8.1.0" useFeatures="true" includeLaunchers="true">
+<product name="idempiere Swing Client" uid="org.adempiere.ui.swing.product" id="org.adempiere.ui.swing.client_product" application="org.adempiere.ui.swing.client" version="8.2.0" useFeatures="true" includeLaunchers="true">
 
    <configIni use="default">
    </configIni>
@@ -28,10 +28,10 @@
    </plugins>
 
    <features>
-      <feature id="org.adempiere.base.feature" version="8.1.0.qualifier"/>
-      <feature id="org.adempiere.pipo.feature" version="8.1.0.qualifier"/>
-      <feature id="org.adempiere.ui.swing.feature" version="8.1.0.qualifier"/>
-      <feature id="org.idempiere.hazelcast.service.feature" version="8.1.0.qualifier"/>
+      <feature id="org.adempiere.base.feature" version="8.2.0.qualifier"/>
+      <feature id="org.adempiere.pipo.feature" version="8.2.0.qualifier"/>
+      <feature id="org.adempiere.ui.swing.feature" version="8.2.0.qualifier"/>
+      <feature id="org.idempiere.hazelcast.service.feature" version="8.2.0.qualifier"/>
    </features>
 
    <configurations>

--- a/org.idempiere.swing.client.parent/pom.xml
+++ b/org.idempiere.swing.client.parent/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.idempiere.swing.client</groupId>
 	<artifactId>org.idempiere.swing.client.parent</artifactId>
-	<version>8.1.0-SNAPSHOT</version>
+	<version>8.2.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>Maven parent project for iDempiere Swing Client</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
         <parent>
                 <groupId>org.idempiere.swing.client</groupId>
                 <artifactId>org.idempiere.swing.client.parent</artifactId>
-                <version>8.1.0-SNAPSHOT</version>
+                <version>8.2.0-SNAPSHOT</version>
                 <relativePath>org.idempiere.swing.client.parent/pom.xml</relativePath>
         </parent>
         <properties>


### PR DESCRIPTION
The only real change is in swingclient.product.launch, but it doesn't compile with latest unless we change the version to 8.2
b/org.adempiere.ui.swing-feature/swingclient.product.launch