### PR TITLE
IDEMPIERE-4923 Export failed in Swing client

### DIFF
--- a/org.adempiere.ui.swing-feature/swingclient.product.launch
+++ b/org.adempiere.ui.swing-feature/swingclient.product.launch
@@ -165,6 +165,7 @@
         <setEntry value="org.apache.commons.lang3@default:default"/>
         <setEntry value="org.apache.commons.lang@default:default"/>
         <setEntry value="org.apache.commons.logging@default:default"/>
+        <setEntry value="org.apache.commons.math3@default:default"/>
         <setEntry value="org.apache.commons.net@default:default"/>
         <setEntry value="org.apache.cxf.cxf-core@default:default"/>
         <setEntry value="org.apache.cxf.cxf-rt-bindings-soap@default:default"/>


### PR DESCRIPTION
Add org.apache.commons.math3 as dependence, which is needed by org.apache.poi.poi.