### PR TITLE
IDEMPIERE-4928 NPE after disabling "Cache Windows" option in Swing client

### DIFF
--- a/org.adempiere.ui.swing/src/org/compiere/apps/APanel.java
+++ b/org.adempiere.ui.swing/src/org/compiere/apps/APanel.java
@@ -245,6 +245,8 @@ public final class APanel extends CPanel
 			m_curAPanelTab = null;
 		}
 		//  close panels
+		for (ChangeListener listener : tabPanel.getChangeListeners())
+			tabPanel.removeChangeListener(listener);
 		tabPanel.dispose(this);
 		tabPanel = null;
 		//  All Workbenches


### PR DESCRIPTION
When disposing APanel, firstly trying to remove all change listeners of VTabbedPane, before calling it's dispose().