### PR TITLE
IDEMPIERE-4930: NPE when changing themes from Nimbus

### DIFF
--- a/org.adempiere.ui.swing/src/org/adempiere/plaf/PLAFEditorPanel.java
+++ b/org.adempiere.ui.swing/src/org/adempiere/plaf/PLAFEditorPanel.java
@@ -187,7 +187,7 @@ public class PLAFEditorPanel extends CPanel {
 		updatePreviewComponents();
 		setLFSelection();
 		setCursor(Cursor.getPredefinedCursor(Cursor.DEFAULT_CURSOR));
-		this.repaint();
+		previewPanel.paint(previewPanel.getGraphics());
 	}
 
 	/**
@@ -206,7 +206,7 @@ public class PLAFEditorPanel extends CPanel {
 		updatePreviewComponents();
 		setLFSelection();
 		setCursor(Cursor.getPredefinedCursor(Cursor.DEFAULT_CURSOR));
-		this.repaint();
+		previewPanel.paint(previewPanel.getGraphics());
 	}
 
 	private void updatePreviewComponents() {
@@ -422,6 +422,7 @@ class PreviewPanel extends CPanel {
 					UIManager.setLookAndFeel(laf);
 				} catch (UnsupportedLookAndFeelException e) {
 				}
+				SwingUtilities.updateComponentTreeUI(this);
 				laf = null;
 				theme = null;
 			}


### PR DESCRIPTION
According to document of
javax.swing.plaf.metal.MetalLookAndFeel.setCurrentTheme(), a call to
SwingUtilities.updateComponentTreeUI() is needed after theme change.

This commit contains two modifications:

1. An asynchronous repaint() may cause problem if some other components
are scheduled to repaint before previewPanel, and those components have
not been updated by updateComponentTreeUI(). This commit try to call
previewPanel.paint() directly to do a synchronized redraw, so that
original theme can be restored immediately after preview image is
captured.

2. After restoring original theme in previewPanel.paint(), call
updateComponentTreeUI() for previewPanel again.