### PR TITLE
IDEMPIERE-4934 Key <F6> or <F8> does not function in newly opened windows

### DIFF
--- a/org.adempiere.ui.swing/src/org/compiere/grid/GridController.java
+++ b/org.adempiere.ui.swing/src/org/compiere/grid/GridController.java
@@ -225,6 +225,8 @@ public class GridController extends CPanel
 		splitPane.add(cardPanel, JSplitPane.RIGHT);
 		splitPane.setBorder(null);
 		splitPane.setName("gc_splitPane");
+		splitPane.getInputMap(WHEN_ANCESTOR_OF_FOCUSED_COMPONENT).put(KeyStroke.getKeyStroke("F6"), "none");
+		splitPane.getInputMap(WHEN_ANCESTOR_OF_FOCUSED_COMPONENT).put(KeyStroke.getKeyStroke("F8"), "none");
 		//
 		cardPanel.setLayout(cardLayout);
 		cardPanel.add(vPane, "vPane");	//	Sequence Important!


### PR DESCRIPTION
Disable default keymaps for F6 and F8 in JSplitPane inside
GridController, which conflict with "Lookup Record" and "Grid Toggle" in
menu and toolbar.