### PR TITLE
IDEMPIERE-4947 Improve modification indication UX for text input

### DIFF
--- a/org.adempiere.ui.swing/src/org/compiere/grid/ed/VCellEditor.java
+++ b/org.adempiere.ui.swing/src/org/compiere/grid/ed/VCellEditor.java
@@ -34,7 +34,6 @@ import javax.swing.table.TableCellEditor;
 
 import org.adempiere.plaf.AdempierePLAF;
 import org.compiere.model.GridField;
-import org.compiere.model.GridTable;
 import org.compiere.util.CLogger;
 
 /**
@@ -206,7 +205,7 @@ public final class VCellEditor extends AbstractCellEditor
 			return;
 		if (log.isLoggable(Level.FINE)) log.fine(e.getPropertyName() + "=" + e.getNewValue());
 		//
-		((GridTable)m_table.getModel()).setChanged(true);
+		m_table.setValueAt(e.getNewValue(), m_table.getEditingRow(), m_table.getEditingColumn());
 	}   //  vetoableChange
 
 	/**

--- a/org.adempiere.ui.swing/src/org/compiere/grid/ed/VMemo.java
+++ b/org.adempiere.ui.swing/src/org/compiere/grid/ed/VMemo.java
@@ -161,7 +161,7 @@ public class VMemo extends CTextArea
 	 */
 	public void propertyChange (PropertyChangeEvent evt)
 	{
-		if (evt.getPropertyName().equals(org.compiere.model.GridField.PROPERTY))
+		if (evt.getPropertyName().equals(org.compiere.model.GridField.PROPERTY) && !getText().equals(evt.getNewValue()))
 			setValue(evt.getNewValue());
 	}   //  propertyChange
 

--- a/org.adempiere.ui.swing/src/org/compiere/grid/ed/VMemo.java
+++ b/org.adempiere.ui.swing/src/org/compiere/grid/ed/VMemo.java
@@ -20,15 +20,12 @@ import java.awt.Component;
 import java.awt.Container;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.awt.event.FocusEvent;
-import java.awt.event.FocusListener;
 import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyVetoException;
-import java.util.logging.Level;
 
 import javax.swing.InputVerifier;
 import javax.swing.JComponent;
@@ -53,7 +50,7 @@ import org.compiere.util.Msg;
  *  @version 	$Id: VMemo.java,v 1.2 2006/07/30 00:51:27 jjanke Exp $
  */
 public class VMemo extends CTextArea
-	implements VEditor, KeyListener, FocusListener, ActionListener
+	implements VEditor, KeyListener, ActionListener
 {
 	/**
 	 * 
@@ -115,7 +112,6 @@ public class VMemo extends CTextArea
 		super (fieldLength/80, 50);
 		super.setName(columnName);
 		LookAndFeel.installBorder(this, "TextField.border");
-		this.addFocusListener(this);    //  to activate editor
 
 		//  Create Editor
 		setColumns(displayLength>VString.MAXDISPLAY_LENGTH ? VString.MAXDISPLAY_LENGTH : displayLength);	//  46
@@ -124,7 +120,6 @@ public class VMemo extends CTextArea
 
 		setLineWrap(true);
 		setWrapStyleWord(true);
-		addFocusListener(this);
 		setInputVerifier(new CInputVerifier()); //Must be set AFTER addFocusListener in order to work
 		setMandatory(mandatory);
 		m_columnName = columnName;
@@ -157,22 +152,8 @@ public class VMemo extends CTextArea
 
 	private String		m_columnName;
 	private String		m_oldText = "";
-	private volatile boolean	m_setting = false;
 	/**	Logger			*/
 	private static CLogger log = CLogger.getCLogger(VMemo.class);
-
-	/**
-	 *	Set Editor to value
-	 *  @param value
-	 */
-	public void setValue(Object value)
-	{
-		super.setValue(value);
-		if (m_setting)
-			return;
-		//	Always position Top 
-		setCaretPosition(0);
-	}	//	setValue
 
 	/**
 	 *  Property Change Listener
@@ -247,35 +228,12 @@ public class VMemo extends CTextArea
 			setText(m_oldText);
 			return;
 		}
-	}	//	keyReleased
-
-	/**
-	 *	Focus Gained	- Save for Escape
-	 *  @param e
-	 */
-	public void focusGained (FocusEvent e)
-	{
-		if (log.isLoggable(Level.CONFIG)) log.config(e.paramString());
-		if (e.getSource() instanceof VMemo)
-			requestFocus();
-		else
-			m_oldText = getText();
-	}	//	focusGained
-
-	/**
-	 *	Data Binding to MTable (via GridController)
-	 *  @param e
-	 */
-	public void focusLost (FocusEvent e)
-	{
-		m_setting = true;
 		try
 		{
 			fireVetoableChange(m_columnName, m_oldText, getText());
 		}
-		catch (PropertyVetoException pve)	{}
-		m_setting = false;
-	}	//	focusLost
+		catch (PropertyVetoException pve) {}
+	}	//	keyReleased
 
 	/*************************************************************************/
 

--- a/org.adempiere.ui.swing/src/org/compiere/grid/ed/VText.java
+++ b/org.adempiere.ui.swing/src/org/compiere/grid/ed/VText.java
@@ -161,7 +161,7 @@ public class VText extends CTextArea
 	 */
 	public void propertyChange (PropertyChangeEvent evt)
 	{
-		if (evt.getPropertyName().equals(org.compiere.model.GridField.PROPERTY))
+		if (evt.getPropertyName().equals(org.compiere.model.GridField.PROPERTY) && !getText().equals(evt.getNewValue()))
 			setValue(evt.getNewValue());
 	}   //  propertyChange
 

--- a/org.adempiere.ui.swing/src/org/compiere/grid/ed/VText.java
+++ b/org.adempiere.ui.swing/src/org/compiere/grid/ed/VText.java
@@ -20,8 +20,6 @@ import java.awt.Component;
 import java.awt.Container;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.awt.event.FocusEvent;
-import java.awt.event.FocusListener;
 import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
 import java.awt.event.MouseAdapter;
@@ -50,7 +48,7 @@ import org.compiere.util.Msg;
  *  @version 	$Id: VText.java,v 1.2 2006/07/30 00:51:28 jjanke Exp $
  */
 public class VText extends CTextArea
-	implements VEditor, KeyListener, ActionListener, FocusListener
+	implements VEditor, KeyListener, ActionListener
 {
 
 	/**
@@ -117,7 +115,6 @@ public class VText extends CTextArea
 		if (isReadOnly || !isUpdateable)
 			setReadWrite(false);
 		addKeyListener(this);
-		addFocusListener(this);
 
 		//	Popup
 		addMouseListener(new VText_mouseAdapter(this));
@@ -142,7 +139,6 @@ public class VText extends CTextArea
 	private String				m_columnName;
 	private String				m_oldText;
 	private String				m_initialText;
-	private volatile boolean	m_setting = false;
 	private GridField m_mField;
 
 	/**
@@ -155,12 +151,8 @@ public class VText extends CTextArea
 			m_oldText = "";
 		else
 			m_oldText = value.toString();
-		if (m_setting)
-			return;
 		super.setValue(m_oldText);
 		m_initialText = m_oldText;
-		//	Always position Top 
-		setCaretPosition(0);
 	}	//	setValue
 
 	/**
@@ -236,6 +228,11 @@ public class VText extends CTextArea
 		//  ESC
 		if (e.getKeyCode() == KeyEvent.VK_ESCAPE)
 			setText(m_initialText);
+		try
+		{
+			fireVetoableChange(m_columnName, m_oldText, getText());
+		}
+		catch (PropertyVetoException pve) {}
 	}	//	keyReleased
 
 	/**
@@ -253,22 +250,7 @@ public class VText extends CTextArea
 	public GridField getField() {
 		return m_mField;
 	}
-	
-	@Override
-	public void focusGained(FocusEvent e) {
-	}
 
-	@Override
-	public void focusLost(FocusEvent e) {
-		m_setting = true;
-		try
-		{
-			fireVetoableChange(m_columnName, m_oldText, getText());
-		}
-		catch (PropertyVetoException pve)	{}
-		m_setting = false;
-	}
-	
 	/**
 	 * 	Get Focus Component
 	 *	@return component


### PR DESCRIPTION
Instead of only indicating data is modified after focus is moving out of
text input field, it is better to mark modification immediately after
text content is changed.

With this change, users can type F4 or click Save icon in toolbar to
save data after text editing, without having to move focus out of
text input field.

See screencasts in JIRA issue for more detail: https://idempiere.atlassian.net/browse/IDEMPIERE-4947